### PR TITLE
Removing redditp.com which is a slideshow creator for reddit.

### DIFF
--- a/UK-Community.txt
+++ b/UK-Community.txt
@@ -54552,7 +54552,6 @@ redditocreativita.com
 redditodicittadinanza.online
 redditodiemergenza.online
 redditonline.com
-redditp.com
 redditpharma.com
 redditpics.club
 redditplay.com


### PR DESCRIPTION
redditp.com is a safe slideshow creator for reddit.com. Since this list is about sites that impersonate official sites, redditp.com is wrong to be included. 

cc: @ubershmekel