### PR TITLE
Remove keepassxc.org

### DIFF
--- a/UK-Community.txt
+++ b/UK-Community.txt
@@ -34572,7 +34572,6 @@ keepassxc.com
 keepassxc.ga
 keepassxc.info
 keepassxc.net
-keepassxc.org
 keepassxx.country
 keeperofthewellmassageky.com
 keepersofthethree-fold-flamelovewisdomandpower.com


### PR DESCRIPTION
KeePassXC is a popular fork of KeePass: https://github.com/keepassxreboot/keepassxc and keepassxc.org is their official website. 